### PR TITLE
Bump parsley version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-Parsley==1.1pre1
+Parsley>=1.1pre1


### PR DESCRIPTION
Specifying version equality is too strict. Also, that pre-release isn't on PyPI.
