### PR TITLE
Add a convenience method

### DIFF
--- a/edn.py
+++ b/edn.py
@@ -36,3 +36,7 @@ edn = makeGrammar(open('edn.parsley').read(),
                     'TaggedValue': TaggedValue
                   },
                   name='edn')
+
+
+def loads(string):
+    return edn(string).edn()

--- a/test_edn.py
+++ b/test_edn.py
@@ -1,6 +1,6 @@
 import unittest
 
-from edn import edn, Symbol, Keyword, Vector, TaggedValue
+from edn import edn, loads, Symbol, Keyword, Vector, TaggedValue
 
 
 
@@ -92,6 +92,13 @@ baz\"""").string(), '\nfoo\nbar\nbaz')
 
     def test_discard(self):
         self.assertEqual(edn('[1 2 #_foo 3]').edn(), Vector([1, 2, 3]))
+
+
+class LoadsTestCase(unittest.TestCase):
+
+    def test_structure(self):
+        self.assertEqual(set([1,2,3]), loads('#{1 2 3}'))
+        self.assertEqual({1: 2, 3: 4}, loads('{1 2, 3 4}'))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Hello dreid,

This patch adds a convenience method, `loads`, which takes a string and returns the parsed form. It's something that any user of the API will want, and it also provides a convenient launching point for the rest of the work.

cheers,
jml
