### PR TITLE
Maps!

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /*.egg-info
 /_trial_temp
 /dist
+/.testrepository

--- a/.testr.conf
+++ b/.testr.conf
@@ -1,0 +1,4 @@
+[DEFAULT]
+test_command=${PYTHON:-python} -m subunit.run discover . $LISTOPT $IDOPTION
+test_id_option=--load-list $IDFILE
+test_list_option=--list

--- a/edn/__init__.py
+++ b/edn/__init__.py
@@ -9,4 +9,6 @@ from ._edn import (
     edn,
     loads,
     make_tagged_value,
+    DEFAULT_WRITE_HANDLERS,
+    tagger,
 )

--- a/edn/_edn.py
+++ b/edn/_edn.py
@@ -4,8 +4,9 @@ from functools import partial
 import os
 import uuid
 
-from parsley import makeGrammar, wrapGrammar
 import iso8601
+from parsley import makeGrammar, wrapGrammar
+from perfidy import frozendict
 
 
 class Symbol(namedtuple("Symbol", "name prefix type")):
@@ -64,6 +65,7 @@ _unwrapped_edn = makeGrammar(
         'Keyword': Keyword,
         'Vector': Vector,
         'TaggedValue': partial(make_tagged_value, BUILTIN_READ_HANDLERS),
+        'frozendict': frozendict,
     },
     name='edn',
     unwrap=True)

--- a/edn/edn.parsley
+++ b/edn/edn.parsley
@@ -238,7 +238,7 @@ vector = '[' elem*:elems ']' -> Vector(elems)
 
 pair = datum:k consumable datum:v -> (k, v)
 members = (pair:first (consumable pair)*:rest -> [first] + rest) | -> []
-map = '{' consumable members:m consumable '}' -> dict(m)
+map = '{' consumable members:m consumable '}' -> frozendict(m)
 
 # ### sets
 #

--- a/edn/tests/test_edn.py
+++ b/edn/tests/test_edn.py
@@ -6,6 +6,7 @@ import uuid
 import pytz
 
 from edn import (
+    DEFAULT_WRITE_HANDLERS,
     Keyword,
     Symbol,
     TaggedValue,
@@ -282,6 +283,18 @@ class DumpsTestCase(unittest.TestCase):
         foo = namedtuple('foo', 'x y')
         a = foo(1, 2)
         self.assertEqual('(1 2)', dumps(a))
+
+    def test_custom_handler(self):
+        foo = namedtuple('foo', 'x y')
+        handler = lambda x: TaggedValue(Symbol('foo'), (x.x, x.y))
+        handlers = DEFAULT_WRITE_HANDLERS + [(foo, handler)]
+        self.assertEqual('#foo (2 3)', dumps(foo(2, 3), handlers))
+
+    def test_nested_custom_handler(self):
+        foo = namedtuple('foo', 'x y')
+        handler = lambda x: TaggedValue(Symbol('foo'), (x.x, x.y))
+        handlers = DEFAULT_WRITE_HANDLERS + [(foo, handler)]
+        self.assertEqual('(#foo (2 3))', dumps([foo(2, 3)], handlers))
 
 
 if __name__ == '__main__':

--- a/edn/tests/test_edn.py
+++ b/edn/tests/test_edn.py
@@ -4,6 +4,7 @@ import unittest
 import uuid
 
 import iso8601
+from perfidy import frozendict
 
 from edn import (
     DEFAULT_WRITE_HANDLERS,
@@ -88,10 +89,10 @@ baz\"""").string(), '\nfoo\nbar\nbaz')
             self.assertEqual(edn(edn_str).vector(), expected)
 
     def test_map(self):
-        maps = [("{}", {}),
-                ("{1 2}", {1: 2}),
+        maps = [("{}", frozendict({})),
+                ("{1 2}", frozendict({1: 2})),
                 ("{[1] {2 3}, (4 5 6), 7}",
-                 {(1,): {2: 3}, (4, 5, 6): 7})]
+                 frozendict({(1,): frozendict({2: 3}), (4, 5, 6): 7}))]
 
         for edn_str, expected in maps:
             self.assertEqual(edn(edn_str).map(), expected)
@@ -132,7 +133,7 @@ class LoadsTestCase(unittest.TestCase):
 
     def test_structure(self):
         self.assertEqual(set([1,2,3]), loads('#{1 2 3}'))
-        self.assertEqual({1: 2, 3: 4}, loads('{1 2, 3 4}'))
+        self.assertEqual(frozendict({1: 2, 3: 4}), loads('{1 2, 3 4}'))
 
     def test_custom_tag(self):
         text = '#foo [1 2]'

--- a/setup.py
+++ b/setup.py
@@ -9,5 +9,6 @@ setup(
     install_requires=[
         'iso8601',
         'parsley>=1.1pre1',
+        'perfidy',
     ],
 )


### PR DESCRIPTION
This makes [perfidy](https://github.com/jml/perfidy) a dependency, and uses it for immutable maps.

I'll add a test that shows maps can be keys of maps. This depends on `releasable`
