### PR TITLE
Tagged value fix

### DIFF
--- a/edn/edn.parsley
+++ b/edn/edn.parsley
@@ -307,7 +307,7 @@ set = '#{' elem*:elems '}' -> Set(elems)
 # canonical UUID string representation.
 #
 
-tag = '#' symbol:t spaces datum:v -> TaggedValue(t, v)
+tag = '#' symbol:t consumable datum:v -> TaggedValue(t, v)
 
 # ## comments
 #

--- a/edn/tests/test_ast.py
+++ b/edn/tests/test_ast.py
@@ -116,6 +116,9 @@ baz\"""").string(), String('\nfoo\nbar\nbaz'))
     def test_tag(self):
         tags = [
             ('#foo/bar baz', TaggedValue(Symbol('bar', 'foo'), Symbol('baz'))),
+            ('#foo     baz', TaggedValue(Symbol('foo'), Symbol('baz'))),
+            ('#foo\n  baz', TaggedValue(Symbol('foo'), Symbol('baz'))),
+            ('#foo ; comment\nbar', TaggedValue(Symbol('foo'), Symbol('bar'))),
         ]
         for edn_str, expected in tags:
             self.assertEqual(edn(edn_str).tag(), expected)

--- a/edn/tests/test_ast.py
+++ b/edn/tests/test_ast.py
@@ -114,8 +114,11 @@ baz\"""").string(), String('\nfoo\nbar\nbaz'))
             self.assertEqual(edn(edn_str).set(), expected)
 
     def test_tag(self):
-        self.assertEqual(edn('#foo/bar baz').tag(),
-                         TaggedValue(Symbol('bar', 'foo'), Symbol('baz')))
+        tags = [
+            ('#foo/bar baz', TaggedValue(Symbol('bar', 'foo'), Symbol('baz'))),
+        ]
+        for edn_str, expected in tags:
+            self.assertEqual(edn(edn_str).tag(), expected)
 
     def test_comment(self):
         self.assertEqual(


### PR DESCRIPTION
Turns out that tagged values can have comments & discards between the tag and the element.
