### PR TITLE
Streaming support for load & dump

### DIFF
--- a/edn/__init__.py
+++ b/edn/__init__.py
@@ -4,5 +4,6 @@ from ._ast import (
 )
 from ._extended import (
     dumps,
+    load,
     loads,
 )

--- a/edn/__init__.py
+++ b/edn/__init__.py
@@ -3,6 +3,7 @@ from ._ast import (
     Symbol,
 )
 from ._extended import (
+    dump,
     dumps,
     load,
     loads,

--- a/edn/_ast.py
+++ b/edn/_ast.py
@@ -157,7 +157,14 @@ def unparse(obj):
     return coerceToTerm(obj).build(builder)
 
 
-def unparse_stream(input_stream):
+def unparse_stream(input_elements, output_stream):
+    """Write abstract edn elements out as edn to a file-like object.
+
+    Elements will be separated by UNIX newlines.  This may change in future
+    versions.
+    """
+    separator = u'\n'.encode('utf8')
     builder = _Builder()
-    for element in input_stream:
-        yield coerceToTerm(element).build(builder)
+    for element in input_elements:
+        output_stream.write(coerceToTerm(element).build(builder))
+        output_stream.write(separator)

--- a/edn/_ast.py
+++ b/edn/_ast.py
@@ -22,6 +22,8 @@ import os
 from parsley import makeGrammar
 from terml.nodes import coerceToTerm, termMaker as t
 
+from ._parsley import iterGrammar, parseGrammar
+
 
 Character = t.Character
 Keyword = t.Keyword
@@ -38,21 +40,21 @@ Vector = t.Vector
 _edn_grammar_file = os.path.join(os.path.dirname(__file__), 'edn.parsley')
 _edn_grammar_definition = open(_edn_grammar_file).read()
 
-edn = makeGrammar(
-    _edn_grammar_definition,
-    {
-        'Character': Character,
-        'String': String,
-        'Symbol': Symbol,
-        'Keyword': Keyword,
-        'Vector': Vector,
-        'TaggedValue': TaggedValue,
-        'Map': Map,
-        'Nil': Nil,
-        'Set': Set,
-        'List': List,
-    },
-    name='edn')
+_edn_bindings = {
+    'Character': Character,
+    'String': String,
+    'Symbol': Symbol,
+    'Keyword': Keyword,
+    'Vector': Vector,
+    'TaggedValue': TaggedValue,
+    'Map': Map,
+    'Nil': Nil,
+    'Set': Set,
+    'List': List,
+}
+
+_parsed_edn = parseGrammar(_edn_grammar_definition, 'edn')
+edn = makeGrammar(_edn_grammar_definition, _edn_bindings, name='edn')
 
 
 def parse(string):
@@ -61,6 +63,10 @@ def parse(string):
     Returns an abstract representation of a single edn element.
     """
     return edn(string).edn()
+
+
+def parse_stream(stream):
+    return iterGrammar(_parsed_edn, _edn_bindings, 'edn', stream)
 
 
 def _wrap(start, end, *middle):

--- a/edn/_ast.py
+++ b/edn/_ast.py
@@ -155,3 +155,9 @@ def unparse(obj):
     """
     builder = _Builder()
     return coerceToTerm(obj).build(builder)
+
+
+def unparse_stream(input_stream):
+    builder = _Builder()
+    for element in input_stream:
+        yield coerceToTerm(element).build(builder)

--- a/edn/_extended.py
+++ b/edn/_extended.py
@@ -29,6 +29,7 @@ from ._ast import (
     TaggedValue,
     Vector,
     parse,
+    parse_stream,
     unparse,
 )
 
@@ -132,6 +133,25 @@ def loads(string, readers=frozendict(), default=None):
     :return: A Python object representing the edn element.
     """
     return from_terms(parse(string), readers, default)
+
+
+# XXX: Take readers & default
+def load(stream):
+    """Interpret an edn stream.
+
+    Load an edn stream lazily as a Python iterator over the elements defined
+    in stream.  We can do this because edn does not mandate a top-level
+    enclosing element.
+
+    See https://github.com/edn-format/edn.
+
+    :param stream: A file-like object of UTF-8 encoded text containing edn data.
+    :return: An iterator of Python objects representing the edn elements in
+        the stream.
+
+    """
+    for term in parse_stream(stream):
+        yield from_terms(term)
 
 
 def _get_tag_name(obj):

--- a/edn/_extended.py
+++ b/edn/_extended.py
@@ -135,8 +135,7 @@ def loads(string, readers=frozendict(), default=None):
     return from_terms(parse(string), readers, default)
 
 
-# XXX: Take readers & default
-def load(stream):
+def load(stream, readers=frozendict(), default=None):
     """Interpret an edn stream.
 
     Load an edn stream lazily as a Python iterator over the elements defined
@@ -146,12 +145,18 @@ def load(stream):
     See https://github.com/edn-format/edn.
 
     :param stream: A file-like object of UTF-8 encoded text containing edn data.
+    :param readers: A map from tag symbols to callables.  For '#foo bar'
+        whatever callable the Symbol('foo') key is mapped to will be
+        called with 'bar'.  There are default readers for #inst and #uuid,
+        which can be overridden here.
+    :param default: Called whenever we come across a tagged value that is not
+        mentioned in `readers'.  It gets the symbol and the interpreted value,
+        and whatever it returns is how that value will be interpreted.
     :return: An iterator of Python objects representing the edn elements in
         the stream.
-
     """
     for term in parse_stream(stream):
-        yield from_terms(term)
+        yield from_terms(term, readers, default=default)
 
 
 def _get_tag_name(obj):

--- a/edn/_extended.py
+++ b/edn/_extended.py
@@ -31,6 +31,7 @@ from ._ast import (
     parse,
     parse_stream,
     unparse,
+    unparse_stream,
 )
 
 
@@ -217,4 +218,38 @@ def to_terms(obj, writers=(), default=_default_handler):
 
 
 def dumps(obj, writers=(), default=_default_handler):
+    """Convert a single object to valid edn.
+
+    :param obj: The object to be converted to edn.
+    :param writers: A sequence of (type, symbol, callable) for encoding types
+        that are not immediately supported by edn.  Any object that matches
+        'type' (as determined by isinstance) will be turned into a tagged
+        value, where the tag is 'symbol', and the value is the edn-encoded
+        result of 'callable(obj)'.
+    :param default: Used to handle any object for which there isn't a defined
+        writer.  Unary callable taking the unrecognized object.  Will raise
+        ValueError by default.
+    """
     return unparse(to_terms(obj, writers, default))
+
+
+def dump(objs, output_stream, writers=(), default=_default_handler):
+    """Write a sequence of objects as edn.
+
+    Elements will be separated by UNIX newlines.  This may change in future
+    versions.
+
+    :param objs: An iterable of objects to be written as edn.
+    :param output_stream: A file-like object to write the edn data to.
+    :param writers: A sequence of (type, symbol, callable) for encoding types
+        that are not immediately supported by edn.  Any object that matches
+        'type' (as determined by isinstance) will be turned into a tagged
+        value, where the tag is 'symbol', and the value is the edn-encoded
+        result of 'callable(obj)'.
+    :param default: Used to handle any object for which there isn't a defined
+        writer.  Unary callable taking the unrecognized object.  Will raise
+        ValueError by default.
+
+    """
+    terms = (to_terms(obj, writers, default) for obj in objs)
+    unparse_stream(terms, output_stream)

--- a/edn/_parsley.py
+++ b/edn/_parsley.py
@@ -1,0 +1,57 @@
+"""
+Things for working with parsley.
+"""
+
+from ometa.interp import TrampolinedGrammarInterpreter, _feed_me
+from ometa.grammar import OMeta
+
+
+def parseGrammar(definition, name='Grammar'):
+    return OMeta(definition).parseGrammar(name)
+
+
+# TODO: Remove when parsley released with
+# https://github.com/python-parsley/parsley/pull/45
+def _pumpInterpreter(interpFactory, dataChunk, interp=None):
+    if interp is None:
+        interp = interpFactory()
+    while dataChunk:
+        status = interp.receive(dataChunk)
+        if status is _feed_me:
+            break
+        dataChunk = ''.join(interp.input.data[interp.input.position:])
+        interp = interpFactory()
+    if not interp.ended:
+        interp.end()
+    return interp
+
+
+# TODO: Remove when parsley released with
+# https://github.com/python-parsley/parsley/pull/45
+def iterGrammar(grammar, bindings, rule, input_stream):
+    """
+    Repeatedly apply rule to an input stream, and yield matches.
+
+    @param grammar: An ometa grammar.
+    @param rule: The name of the rule to match.  Matches will be yielded.
+    @param input_stream: The stream to read.  Will be read incrementally.
+    """
+    tokens = []  # Should really be an explicit queue.
+    def append(token, error):
+        if error.error:
+            raise error
+        tokens.append(token)
+
+    def makeInterpreter():
+        return TrampolinedGrammarInterpreter(
+            grammar, rule, callback=append, globals=bindings)
+
+    while True:
+        data = input_stream.read()
+        if not data:
+            break
+        _pumpInterpreter(makeInterpreter, data)
+        for token in tokens:
+            yield token
+        tokens[:] = []
+

--- a/edn/tests/test_ast.py
+++ b/edn/tests/test_ast.py
@@ -136,13 +136,15 @@ class ParseTestCase(unittest.TestCase):
 
 class ParseStreamTestCase(unittest.TestCase):
 
-    def test_stream(self):
+    def test_iterator(self):
         stream = StringIO('1 2 #{4 5} "foo" [bar qux]')
-        parsed = list(parse_stream(stream))
-        expected = [
-            1, 2, Set([4, 5]), String("foo"),
-            Vector((Symbol('bar'), Symbol('qux')))]
-        self.assertEqual(expected, parsed)
+        output = parse_stream(stream)
+        self.assertEqual(1, output.next())
+        self.assertEqual(2, output.next())
+        self.assertEqual(Set([4, 5]), output.next())
+        self.assertEqual(String("foo"), output.next())
+        self.assertEqual(Vector((Symbol('bar'), Symbol('qux'))), output.next())
+        self.assertRaises(StopIteration, output.next)
 
 
 class UnparseTestCase(unittest.TestCase):

--- a/edn/tests/test_ast.py
+++ b/edn/tests/test_ast.py
@@ -16,6 +16,7 @@ from .._ast import (
     parse,
     parse_stream,
     unparse,
+    unparse_stream,
 )
 
 
@@ -236,3 +237,13 @@ class UnparseTestCase(unittest.TestCase):
         self.assertEqual(
             '#foo "bar"',
             unparse(TaggedValue(Symbol('foo'), String('bar'))))
+
+
+class UnparseStreamTestCase(unittest.TestCase):
+
+    def test_unparse_stream(self):
+        input_stream = iter([Symbol('foo'), String("bar")])
+        output_stream = unparse_stream(input_stream)
+        self.assertEqual('foo', output_stream.next())
+        self.assertEqual('"bar"', output_stream.next())
+        self.assertRaises(StopIteration, output_stream.next)

--- a/edn/tests/test_ast.py
+++ b/edn/tests/test_ast.py
@@ -1,3 +1,4 @@
+from StringIO import StringIO
 import unittest
 
 from .._ast import (
@@ -13,6 +14,7 @@ from .._ast import (
     Vector,
     edn,
     parse,
+    parse_stream,
     unparse,
 )
 
@@ -130,6 +132,17 @@ class ParseTestCase(unittest.TestCase):
     def test_structure(self):
         self.assertEqual(Set([1,2,3]), parse('#{1 2 3}'))
         self.assertEqual(Map([(1, 2), (3, 4)]), parse('{1 2, 3 4}'))
+
+
+class ParseStreamTestCase(unittest.TestCase):
+
+    def test_stream(self):
+        stream = StringIO('1 2 #{4 5} "foo" [bar qux]')
+        parsed = list(parse_stream(stream))
+        expected = [
+            1, 2, Set([4, 5]), String("foo"),
+            Vector((Symbol('bar'), Symbol('qux')))]
+        self.assertEqual(expected, parsed)
 
 
 class UnparseTestCase(unittest.TestCase):

--- a/edn/tests/test_ast.py
+++ b/edn/tests/test_ast.py
@@ -248,8 +248,7 @@ class UnparseTestCase(unittest.TestCase):
 class UnparseStreamTestCase(unittest.TestCase):
 
     def test_unparse_stream(self):
-        input_stream = iter([Symbol('foo'), String("bar")])
-        output_stream = unparse_stream(input_stream)
-        self.assertEqual('foo', output_stream.next())
-        self.assertEqual('"bar"', output_stream.next())
-        self.assertRaises(StopIteration, output_stream.next)
+        output_stream = StringIO()
+        input_elements = iter([Symbol('foo'), String("bar")])
+        unparse_stream(input_elements, output_stream)
+        self.assertEqual('foo\n"bar"\n', output_stream.getvalue())

--- a/edn/tests/test_extended.py
+++ b/edn/tests/test_extended.py
@@ -8,6 +8,7 @@ import iso8601
 from perfidy import frozendict
 
 from edn import (
+    dump,
     dumps,
     load,
     loads,
@@ -344,3 +345,26 @@ class DumpsTestCase(unittest.TestCase):
             '("id" "%s") ("foo" "bar")]'
         ) % (str(uid), str(uid))
         self.assertEqual(expected, dumps(data, writers))
+
+
+class TestDump(unittest.TestCase):
+
+    def test_dump(self):
+        inputs = [{'foo': 42}, set([2, 3, 7])]
+        output = StringIO()
+        dump(inputs, output)
+        self.assertEqual(
+            '{"foo" 42}\n#{2 3 7}\n',
+            output.getvalue())
+
+    def test_custom_writer(self):
+        point = namedtuple('point', 'x y')
+        writer = lambda p: (p.x, p.y)
+        output = StringIO()
+        dump([point(2, 3)], output, [(point, Symbol('point'), writer)])
+        self.assertEqual('#point (2 3)\n', output.getvalue())
+
+    def test_unknown_handler(self):
+        output = StringIO()
+        dump([Custom(42)], output, default=repr)
+        self.assertEqual('"<Custom(42)>"\n', output.getvalue())

--- a/edn/tests/test_extended.py
+++ b/edn/tests/test_extended.py
@@ -117,6 +117,10 @@ class DecoderTests(unittest.TestCase):
         self.assertEqual(uuid.UUID(uid), from_terms(ast))
 
 
+def reverse(x):
+    return list(reversed(x))
+
+
 class LoadsTestCase(unittest.TestCase):
 
     def test_structure(self):
@@ -125,7 +129,7 @@ class LoadsTestCase(unittest.TestCase):
 
     def test_custom_tag(self):
         text = '#foo [1 2]'
-        parsed = loads(text, {Symbol('foo'): lambda x: list(reversed(x))})
+        parsed = loads(text, {Symbol('foo'): reverse})
         self.assertEqual([2, 1], parsed)
 
     def test_custom_default(self):
@@ -155,6 +159,18 @@ class LoadTestCase(unittest.TestCase):
         self.assertEqual(43, stream.next())
         self.assertEqual(32, stream.next())
         self.assertRaises(StopIteration, stream.next)
+
+    def test_custom_tag(self):
+        text = '#foo [1 2] #foo [3 4]'
+        parsed = load(StringIO(text), {Symbol('foo'): reverse})
+        self.assertEqual([[2, 1], [4, 3]], list(parsed))
+
+    def test_custom_default(self):
+        marker = object()
+        handler = lambda a, b: (marker, b)
+        stream = StringIO('#foo [1 2] #bar "qux"')
+        parsed = list(load(stream, default=handler))
+        self.assertEqual([(marker, (1, 2)), (marker, u"qux")], parsed)
 
 
 class Custom(object):

--- a/edn/tests/test_extended.py
+++ b/edn/tests/test_extended.py
@@ -1,5 +1,6 @@
 from collections import namedtuple
 import datetime
+from StringIO import StringIO
 import unittest
 import uuid
 
@@ -8,6 +9,7 @@ from perfidy import frozendict
 
 from edn import (
     dumps,
+    load,
     loads,
     Keyword,
     Symbol,
@@ -137,6 +139,22 @@ class LoadsTestCase(unittest.TestCase):
         loads(text, {foo: lambda x: list(reversed(x))})
         parsed = loads(text)
         self.assertEqual(TaggedValue(foo, (1, 2)), parsed)
+
+
+class LoadTestCase(unittest.TestCase):
+
+    def test_single_element(self):
+        stream = load(StringIO('#{1 2 3}'))
+        self.assertEqual(set([1,2,3]), stream.next())
+        self.assertRaises(StopIteration, stream.next)
+
+    def test_multiple_elements(self):
+        stream = load(StringIO('#{1 2 3} "foo"\n43,32'))
+        self.assertEqual(set([1,2,3]), stream.next())
+        self.assertEqual(u"foo", stream.next())
+        self.assertEqual(43, stream.next())
+        self.assertEqual(32, stream.next())
+        self.assertRaises(StopIteration, stream.next)
 
 
 class Custom(object):


### PR DESCRIPTION
Adds support for reading sources that have multiple edn elements and writing multiple edn elements to a destination.

Adds a new file _parsley.py which has the necessary evil to make this work.  I've also submitted that as a patch to parsley: https://github.com/python-parsley/parsley/pull/45

This depends on the fix to tagged values: https://github.com/dreid/edn/pull/16
