### PR TITLE
Tagged value object separate from AST

### DIFF
--- a/edn/_extended.py
+++ b/edn/_extended.py
@@ -9,6 +9,7 @@ Which can be turned into a Python object::
   [u"foo", u"bar", 43]
 """
 
+import collections
 import datetime
 from decimal import Decimal
 import uuid
@@ -35,6 +36,9 @@ from ._ast import (
     unparse,
     unparse_stream,
 )
+
+
+TaggyWaggyThing = collections.namedtuple('TaggyWaggyThing', 'symbol value')
 
 
 def identity(x):
@@ -79,7 +83,7 @@ class _Decoder(object):
         self._decoders = decoders.with_pair(
             'TaggedValue', self._handle_tagged_value)
         if not default:
-            default = TaggedValue
+            default = TaggyWaggyThing
         self._default = default
 
     def _handle_tagged_value(self, symbol, value):

--- a/edn/tests/test_ast.py
+++ b/edn/tests/test_ast.py
@@ -179,6 +179,7 @@ baz\"""").string(), String('\nfoo\nbar\nbaz'))
             ('#foo     baz', TaggedValue(Symbol('foo'), Symbol('baz'))),
             ('#foo\n  baz', TaggedValue(Symbol('foo'), Symbol('baz'))),
             ('#foo ; comment\nbar', TaggedValue(Symbol('foo'), Symbol('bar'))),
+            ('#foo {}', TaggedValue(Symbol('foo'), Map(()))),
         ]
         for edn_str, expected in tags:
             self.assertEqual(edn(edn_str).tag(), expected)

--- a/edn/tests/test_extended.py
+++ b/edn/tests/test_extended.py
@@ -31,6 +31,7 @@ from .._extended import (
     from_terms,
     to_terms,
     INST,
+    TaggyWaggyThing,
     UUID,
 )
 
@@ -90,11 +91,14 @@ class DecoderTests(unittest.TestCase):
 
     def test_tagged_value(self):
         self.assertEqual(
-            TaggedValue(Symbol('foo'), 'bar'),
+            TaggyWaggyThing(Symbol('foo'), 'bar'),
             from_terms(TaggedValue(Symbol('foo'), String('bar'))))
         self.assertEqual(
-            TaggedValue(Symbol('foo', 'qux'), 'bar'),
+            TaggyWaggyThing(Symbol('foo', 'qux'), 'bar'),
             from_terms(TaggedValue(Symbol('foo', 'qux'), String('bar'))))
+        self.assertEqual(
+            TaggyWaggyThing(Symbol('foo', 'qux'), frozendict()),
+            from_terms(TaggedValue(Symbol('foo', 'qux'), Map(()))))
 
     def test_readers(self):
         ast = TaggedValue(Symbol('foo'), String('bar'))
@@ -172,7 +176,7 @@ class LoadsTestCase(unittest.TestCase):
         text = '#foo [1 2]'
         loads(text, {foo: lambda x: list(reversed(x))})
         parsed = loads(text)
-        self.assertEqual(TaggedValue(foo, (1, 2)), parsed)
+        self.assertEqual(TaggyWaggyThing(foo, (1, 2)), parsed)
 
     def test_tagged_dict(self):
         readers = {Symbol('foo'): lambda x: x}

--- a/edn/tests/test_extended.py
+++ b/edn/tests/test_extended.py
@@ -152,6 +152,11 @@ class LoadsTestCase(unittest.TestCase):
             frozendict({Keyword(Symbol('foo')): Symbol('bar')}),
             loads('{:foo bar}'))
 
+    def test_nested_structure(self):
+        self.assertEqual(
+            frozendict({frozendict({3: 4}): frozendict({1: 2})}),
+            loads('{{3 4} {1 2}}'))
+
     def test_custom_tag(self):
         text = '#foo [1 2]'
         parsed = loads(text, {Symbol('foo'): reverse})
@@ -168,6 +173,11 @@ class LoadsTestCase(unittest.TestCase):
         loads(text, {foo: lambda x: list(reversed(x))})
         parsed = loads(text)
         self.assertEqual(TaggedValue(foo, (1, 2)), parsed)
+
+    def test_tagged_dict(self):
+        readers = {Symbol('foo'): lambda x: x}
+        self.assertEqual(frozendict(), loads('#foo {}', readers))
+        self.assertEqual(frozendict({1: 2}), loads('#foo {1 2}', readers))
 
     def test_nil(self):
         self.assertEqual(None, loads('nil'))
@@ -217,6 +227,7 @@ class LoadTestCase(unittest.TestCase):
         stream = StringIO('#foo [1 2] #bar "qux"')
         parsed = list(load(stream, default=handler))
         self.assertEqual([(marker, (1, 2)), (marker, u"qux")], parsed)
+
 
 
 class Custom(object):


### PR DESCRIPTION
I've given it an obviously terrible name, which ought to be changed before landing.

This is a fix for dreid/edn#24

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/dreid/edn/25)

<!-- Reviewable:end -->
